### PR TITLE
use t/re_base_extraction.t  to benchmark improvements to set_pri_original

### DIFF
--- a/lib/Mail/SpamAssassin/Plugin/BodyRuleBaseExtractor.pm
+++ b/lib/Mail/SpamAssassin/Plugin/BodyRuleBaseExtractor.pm
@@ -404,9 +404,11 @@ NEXT_RULE:
             " base strings extracted in $elapsed seconds\n");
 }
 
-
-
 sub extract_set_pri {
+  # void...
+}
+
+sub extract_set_pri_updated {
   my ($self, $conf, $rules, $ruletype) = @_;
 
   my @good_bases;

--- a/lib/Mail/SpamAssassin/Plugin/BodyRuleBaseExtractor.pm
+++ b/lib/Mail/SpamAssassin/Plugin/BodyRuleBaseExtractor.pm
@@ -123,6 +123,289 @@ sub extract_set {
 
 ###########################################################################
 
+sub extract_set_pri_original {
+  my ($self, $conf, $rules, $ruletype) = @_;
+
+  my @good_bases;
+  my @failed;
+  my $yes = 0;
+  my $no = 0;
+  my $count = 0;
+  my $start = time;
+  $self->{main} = $conf->{main};  # for use in extract_hints()
+  $self->{show_progress} and info ("extracting from rules of type $ruletype");
+  my $tflags = $conf->{tflags};
+
+  # attempt to find good "base strings" (simplified regexp subsets) for each
+  # regexp.  We try looking at the regexp from both ends, since there
+  # may be a good long string of text at the end of the rule.
+
+  # require this many chars in a base string + delimiters for it to be viable
+  my $min_chars = 5;
+
+  my $progress;
+  $self->{show_progress} and $progress = Mail::SpamAssassin::Util::Progress->new({
+                total => (scalar keys %{$rules} || 1),
+                itemtype => 'rules',
+              });
+
+  my $cached = { };
+  my $cachefile;
+
+  if ($self->{main}->{bases_cache_dir}) {
+    $cachefile = $self->{main}->{bases_cache_dir}."/rules.$ruletype";
+    dbg("zoom: reading cache file $cachefile");
+    $cached = $self->read_cachefile($cachefile);
+  }
+
+NEXT_RULE:
+  foreach my $name (keys %{$rules}) {
+    $self->{show_progress} and $progress and $progress->update(++$count);
+
+    my $rule = $rules->{$name};
+    my $cachekey = join "#", $name, $rule;
+
+    my $cent = $cached->{rule_bases}->{$cachekey};
+    if (defined $cent) {
+      if (defined $cent->{g}) {
+        dbg("zoom: YES (cached) $rule $name");
+        foreach my $ent (@{$cent->{g}}) {
+          # note: we have to copy these, since otherwise later
+          # modifications corrupt the cached data
+          push @good_bases, {
+            base => $ent->{base}, orig => $ent->{orig}, name => $ent->{name}
+          };
+        }
+        $yes++;
+      }
+      else {
+        dbg("zoom: NO (cached) $rule $name");
+        push @failed, { orig => $rule };    # no need to cache this
+        $no++;
+      }
+      next NEXT_RULE;
+    }
+
+    # ignore ReplaceTags rules
+    my $is_a_replacetags_rule = $conf->{rules_to_replace}->{$name};
+    my ($minlen, $lossy, @bases);
+
+    if (!$is_a_replacetags_rule) {
+      eval {  # catch die()s
+        my ($qr, $mods) = $self->simplify_and_qr_regexp($rule);
+        ($lossy, @bases) = $self->extract_hints($rule, $qr, $mods);
+      # dbg("zoom: %s %s -> %s", $name, $rule, join(", ", @bases));
+        1;
+      } or do {
+        my $eval_stat = $@ ne '' ? $@ : "errno=$!";  chomp $eval_stat;
+        dbg("zoom: giving up on regexp: $eval_stat");
+      };
+
+      if ($lossy && ($tflags->{$name}||'') =~ /\bmultiple\b/) {
+        warn "\nzoom: rule $name will loop on SpamAssassin older than 3.3.2 ".
+             "running under Perl 5.12 or older, Bug 6558\n";
+      }
+
+      # if any of the extracted hints in a set are too short, the entire
+      # set is invalid; this is because each set of N hints represents just
+      # 1 regexp.
+      foreach my $str (@bases) {
+        my $len = length fixup_re($str); # bug 6143: count decoded characters
+        if ($len < $min_chars) { $minlen = undef; @bases = (); last; }
+        elsif (!defined($minlen) || $len < $minlen) { $minlen = $len; }
+      }
+    }
+
+    if ($is_a_replacetags_rule || !$minlen || !@bases) {
+      dbg("zoom: ignoring rule %s, %s", $name,
+          $is_a_replacetags_rule ? 'is a replace rule'
+          : !@bases ? 'no bases' : 'no minlen');
+      push @failed, { orig => $rule };
+      $cached->{rule_bases}->{$cachekey} = { };
+      $no++;
+    }
+    else {
+      # dbg("zoom: YES <base>$base</base> <origrule>$rule</origrule>");
+
+      # figure out if we have e.g. ["foo", "foob", "foobar"]; in this
+      # case, we only need to track ["foo"].
+      my %subsumed;
+      foreach my $base1 (@bases) {
+        foreach my $base2 (@bases) {
+          if ($base1 ne $base2 && $base1 =~ /\Q$base2\E/) {
+            $subsumed{$base1} = 1; # base2 is inside base1; discard the longer
+          }
+        }
+      }
+
+      my @forcache;
+      foreach my $base (@bases) {
+        next if $subsumed{$base};
+        push @good_bases, {
+            base => $base, orig => $rule, name => "$name,[l=$lossy]"
+          };
+        # *separate* copies for cache -- we modify the @good_bases entry
+        push @forcache, {
+            base => $base, orig => $rule, name => "$name,[l=$lossy]"
+          };
+      }
+
+      $cached->{rule_bases}->{$cachekey} = { g => \@forcache };
+      $yes++;
+    }
+  }
+
+  $self->{show_progress} and $progress and $progress->final();
+
+  dbg("zoom: $ruletype: found ".(scalar @good_bases).
+      " usable base strings in $yes rules, skipped $no rules");
+
+  # NOTE: re2c will attempt to provide the longest pattern that matched; e.g.
+  # ("food" =~ "foo" / "food") will return "food".  So therefore if a pattern
+  # subsumes other patterns, we need to return hits for all of them.  We also
+  # need to take care of the case where multiple regexps wind up sharing the
+  # same base.   
+  #
+  # Another gotcha, an exception to the subsumption rule; if one pattern isn't
+  # entirely subsumed (e.g. "food" =~ "foo" / "ood"), then they will be
+  # returned as two hits, correctly.  So we only have to be smart about the
+  # full-subsumption case; overlapping is taken care of for us, by re2c.
+  #
+  # TODO: there's a bug here.  Since the code in extract_hints() has been
+  # modified to support more complex regexps, we can no longer simply assume
+  # that if pattern A is not contained in pattern B, that means that pattern B
+  # doesn't subsume it.  Consider, for example, A="foo*bar" and
+  # B="morefobarry"; A is indeed subsumed by B, but we won't be able to test
+  # that without running the A RE match itself somehow against B.
+  # same issue remains with:
+  #
+  #   "foo?bar" / "fobar"
+  #   "fo(?:o|oo|)bar" / "fobar"
+  #   "fo(?:o|oo)?bar" / "fobar"
+  #   "fo(?:o*|baz)bar" / "fobar"
+  #   "(?:fo(?:o*|baz)bar|blargh)" / "fobar"
+  #
+  # it's worse with this:
+  #
+  #   "fo(?:o|oo|)bar" / "foo*bar"
+  #
+  # basically, this is impossible to compute without reimplementing most of
+  # re2c, and it appears the re2c developers don't plan to offer this:
+  # https://sourceforge.net/tracker/index.php?func=detail&aid=1540845&group_id=96864&atid=616203
+
+  $conf->{base_orig}->{$ruletype} = { };
+  $conf->{base_string}->{$ruletype} = { };
+
+  $count = 0;
+  $self->{show_progress} and $progress = Mail::SpamAssassin::Util::Progress->new({
+                total => (scalar @good_bases || 1),
+                itemtype => 'bases',
+              });
+
+  # this bit is annoyingly O(N^2).  Rewrite the data -- the @good_bases
+  # array -- into a more efficient format, using arrays and with a little
+  # bit of precomputation, to go (quite a bit) faster
+
+  my @rewritten;
+  foreach my $set1 (@good_bases) {
+    my $base = $set1->{base};
+    next if (!$base || !$set1->{name});
+    push @rewritten, [
+      $base,                # 0
+      $set1->{name},        # 1
+      $set1->{orig},        # 2
+      length $base,         # 3
+      qr/\Q$base\E/,        # 4
+      0                     # 5, has_multiple flag
+    ];
+  }
+  @good_bases = @rewritten;
+
+  foreach my $set1 (@good_bases) {
+    $self->{show_progress} and $progress and $progress->update(++$count);
+
+    my $base1 = $set1->[0]; next unless $base1;
+    my $name1 = $set1->[1];
+    my $orig1 = $set1->[2];
+    $conf->{base_orig}->{$ruletype}->{$name1} = $orig1;
+    my $len1 = $set1->[3];
+
+    foreach my $set2 (@good_bases) {
+      next if ($set1 == $set2);
+
+      my $base2 = $set2->[0]; next unless $base2;
+      my $name2 = $set2->[1];
+
+      # clobber exact dups; this can happen if a regexp outputs the 
+      # same base string multiple times
+      if ($base1 eq $base2 &&
+          $name1 eq $name2 &&
+          $orig1 eq $set2->[2])
+      {
+        $set2->[0] = '';       # clobber
+        next;
+      }
+
+      # skip if it's too short to contain the other base string
+      next if ($len1 < $set2->[3]);
+
+      # skip if either already contains the other rule's name
+      # optimize: this can only happen if the base has more than
+      # one rule already attached, ie [5]
+      next if ($set2->[5] && $name2 =~ /(?: |^)\Q$name1\E(?: |$)/);
+
+      # don't use $name1 here, since another base in the set2 loop
+      # may have added $name2 since we set that
+      next if ($set1->[5] && $set1->[1] =~ /(?: |^)\Q$name2\E(?: |$)/);
+
+      # and finally check to see if it *does* contain the other base string
+      next if ($base1 !~ $set2->[4]);
+
+      # base2 is just a subset of base1
+      # dbg("zoom: subsuming '$base2' ($name2) into '$base1': [1]=$set1->[1] [5]=$set1->[5]");
+      $set1->[1] .= " ".$name2;
+      $set1->[5] = 1;
+    }
+  }
+
+  # we can still have duplicate cases; __FRAUD_PTS and __SARE_FRAUD_BADTHINGS
+  # both contain "killed" for example, pointing at different rules, which
+  # the above search hasn't found.  Collapse them here with a hash
+  my %bases;
+  foreach my $set (@good_bases) {
+    my $base = $set->[0];
+    next unless $base;
+
+    if (defined $bases{$base}) {
+      $bases{$base} .= " ".$set->[1];
+    } else {
+      $bases{$base} = $set->[1];
+    }
+  }
+  undef @good_bases;
+
+  foreach my $base (keys %bases) {
+    # uniq the list, since there are probably dup rules listed
+    my %u;
+    for my $i (split ' ', $bases{$base}) {
+      next if exists $u{$i}; undef $u{$i}; 
+    }
+    $conf->{base_string}->{$ruletype}->{$base} = join ' ', sort keys %u;
+  }
+  $self->{show_progress} and $progress and $progress->final();
+
+  if ($cachefile) {
+    $self->write_cachefile ($cachefile, $cached);
+  }
+
+  my $elapsed = time - $start;
+  $self->{show_progress} and info ("$ruletype: ".
+            (scalar keys %{$conf->{base_string}->{$ruletype}}).
+            " base strings extracted in $elapsed seconds\n");
+}
+
+
+
 sub extract_set_pri {
   my ($self, $conf, $rules, $ruletype) = @_;
 

--- a/t/re_base_extraction.t
+++ b/t/re_base_extraction.t
@@ -449,7 +449,7 @@ sub try_extraction {
 
   # only do it once
   $original_sub //= \&Mail::SpamAssassin::Plugin::BodyRuleBaseExtractor::extract_set_pri_original;
-  $updated_sub //= \&Mail::SpamAssassin::Plugin::BodyRuleBaseExtractor::extract_set_pri;
+  $updated_sub //= \&Mail::SpamAssassin::Plugin::BodyRuleBaseExtractor::extract_set_pri_updated;
 
   
   use Benchmark qw{cmpthese};
@@ -549,7 +549,6 @@ sub try_extraction_light {
 __END__
 
 Benchmark results (using Perl 5.28.0 on a CentOS 7 server)
-
 # Benchmark using RULES
 #
 #
@@ -558,9 +557,9 @@ Benchmark results (using Perl 5.28.0 on a CentOS 7 server)
 #   body FOODOTSTAR /fooBar.*BAZ/
 #   body FOODOTSTAR2 /fooBar(?:BAZ|blarg)/
 #
-           Rate  updated original
-updated  14.0/s       --     -17%
-original 16.8/s      20%       --
+          Rate original  updated
+original 130/s       --      -2%
+updated  133/s       2%       --
 ok 1 - Benchmark done
 # Benchmark using RULES
 #
@@ -570,26 +569,26 @@ ok 1 - Benchmark done
 #   body FOODOTSTAR /foobar.*BAZ/i
 #   body FOODOTSTAR2 /foobar(?:BAZ|blarg)/i
 #
-           Rate  updated original
-updated  7.68/s       --     -10%
-original 8.50/s      11%       --
+          Rate  updated original
+updated  122/s       --      -2%
+original 125/s       2%       --
 ok 2 - Benchmark done
 # Benchmark using RULES
 #
 #
 #   body FOO /(?:(?:bbbb)|dddd (?:eeee )?by|aaaa)/i
 #
-           Rate  updated original
-updated  20.2/s       --      -5%
-original 21.3/s       5%       --
+          Rate original  updated
+original 134/s       --     -12%
+updated  151/s      13%       --
 ok 3 - Benchmark done
 # Benchmark using RULES
 #
 #     body TEST5 /time to refinance|refinanc\w{1,3}\b.{0,16}\bnow\b/i
 #
-           Rate  updated original
-updated  16.3/s       --      -6%
-original 17.4/s       7%       --
+          Rate original  updated
+original 165/s       --      -7%
+updated  177/s       8%       --
 ok 4 - Benchmark done
 # Benchmark using RULES
 #
@@ -597,9 +596,9 @@ ok 4 - Benchmark done
 #     body TEST3 /foody? bar/
 #
 #
-           Rate  updated original
-updated  7.88/s       --     -11%
-original 8.90/s      13%       --
+          Rate  updated original
+updated  121/s       --      -3%
+original 125/s       3%       --
 ok 5 - Benchmark done
 # Benchmark using RULES
 #
@@ -608,9 +607,9 @@ ok 5 - Benchmark done
 #
 #   body __FRAUD_PTS /\b(?:ass?ass?inat(?:ed|ion)|murder(?:e?d)?|kill(?:ed|ing)\b[^.]{0,99}\b(?:war veterans|rebels?))\b/i
 #
-           Rate original  updated
-original 6.67/s       --      -3%
-updated  6.87/s       3%       --
+          Rate  updated original
+updated  129/s       --      -1%
+original 131/s       1%       --
 ok 6 - Benchmark done
 # Benchmark using RULES
 #
@@ -618,34 +617,34 @@ ok 6 - Benchmark done
 #   body VIRUS_WARNING345                /(This message contained attachments that have been blocked by Guinevere|This is an automatic message from the Guinevere Internet Antivirus Scanner)\./
 #   body VIRUS_WARNING345I                /(This message contained attachments that have been blocked by Guinevere|This is an automatic message from the Guinevere Internet Antivirus Scanner)\./i
 #
-           Rate original  updated
-original 6.74/s       --      -9%
-updated  7.45/s      10%       --
+          Rate original  updated
+original 127/s       --     -19%
+updated  156/s      23%       --
 ok 7 - Benchmark done
 # Benchmark using RULES
 #
 #
 #   body FOO /foobar\x{e2}\x{82}\x{ac}baz/
 #
-           Rate  updated original
-updated  11.5/s       --     -11%
-original 12.9/s      13%       --
+          Rate  updated original
+updated  151/s       --      -1%
+original 153/s       1%       --
 ok 8 - Benchmark done
 # Benchmark using RULES
 #
 #     body FOO /(?:Viagra|Valium|Xanax|Soma|Cialis){2}/i
 #
-           Rate original  updated
-original 11.0/s       --     -12%
-updated  12.5/s      14%       --
+          Rate original  updated
+original 130/s       --      -3%
+updated  134/s       3%       --
 ok 9 - Benchmark done
 # Benchmark using RULES
 #
 #     body FOO /\brecords (?:[a-z_,-]+ )+?(?:feature|(?:a|re)ward)/i
 #
-           Rate  updated original
-updated  11.2/s       --     -10%
-original 12.4/s      11%       --
+          Rate  updated original
+updated  108/s       --      -5%
+original 113/s       5%       --
 ok 10 - Benchmark done
 # Benchmark using RULES
 #
@@ -654,9 +653,9 @@ ok 10 - Benchmark done
 #     body TEST1A /fo(?:oish|o) bar/
 #
 #
-           Rate  updated original
-updated  3.80/s       --      -3%
-original 3.92/s       3%       --
+          Rate original  updated
+original 120/s       --     -11%
+updated  135/s      13%       --
 ok 11 - Benchmark done
 # Benchmark using RULES
 #
@@ -664,9 +663,9 @@ ok 11 - Benchmark done
 #     body TEST2 /foody* bar/
 #
 #
-           Rate  updated original
-updated  5.27/s       --      -5%
-original 5.56/s       5%       --
+          Rate original  updated
+original 117/s       --     -21%
+updated  148/s      27%       --
 ok 12 - Benchmark done
 # Benchmark using RULES
 #
@@ -684,9 +683,9 @@ ok 12 - Benchmark done
 #     body TEST7 /(?!credit)[ck\xc7\xe7@]\W?r\W?[e3\xc8\xc9\xca\xcb\xe8\xe9\xea\xeb\xa4]\W?[d\xd0]\W?[il|!1y?\xcc\xcd\xce\xcf\xec\xed\xee\xef]\W?t/i
 #
 #
-         s/iter original  updated
-original   1.10       --     -10%
-updated   0.991      11%       --
+          Rate original  updated
+original 141/s       --      -2%
+updated  144/s       2%       --
 ok 13 - Benchmark done
 # Benchmark using RULES
 #
@@ -699,15 +698,3 @@ ok 13 - Benchmark done
 #     body TEST1 /fo(?:oish|o)? b(a|b)r/
 #     body TEST2 /fo(?:oish|o) b(a|b)r/
 #
-           Rate original  updated
-original 2.38/s       --      -3%
-updated  2.45/s       3%       --
-ok 14 - Benchmark done
-# Benchmark using RULES
-#
-#     body TEST3 /toniospam/i
-#
-           Rate  updated original
-updated  9.57/s       --     -10%
-original 10.7/s      11%       --
-


### PR DESCRIPTION
This Pull Request is just a place holder.

I've used the unit test t/re_base_extraction.t to get some benchmark from the existing tests. 

The speedup improvement depends on the size of the input: body, rules...
but this is mainly a win with all configurations from 3% to 20% speedup improvement

You can view details in the `__END__` section from t/re_base_extraction.t
